### PR TITLE
Add usage example for overriding a package and checking all dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ language: nix
 script:
     - nix-build --argstr reverseDepsOf pretty-simple --arg justPrintAllDeps true
     - cat ./result
-    - nix-build --argstr reverseDepsOf pretty-simple
+    - nix-instantiate --argstr reverseDepsOf pretty-simple
 
 # before_cache:
 #     - mkdir -p $HOME/nix.store

--- a/default.nix
+++ b/default.nix
@@ -96,6 +96,8 @@ let
           then "hydraPlatforms none"
           else if (drv.meta.platforms or lib.platforms.all) == lib.platforms.none
           then "platforms none"
+          else if !(lib.elem stdenv.hostPlatform.system (drv.meta.platforms or lib.platforms.all))
+          then "platform not supported"
           else "not broken"
         );
     in
@@ -131,6 +133,8 @@ let
     then /* builtins.trace "hydraPlatforms none: ${name}" */ true
     else if isBrokenRes == "platforms none"
     then /* builtins.trace "platforms none: ${name}" */ true
+    else if isBrokenRes == "platform not supported"
+    then builtins.trace "system platform (${stdenv.hostPlatform.system}) not supported for package: ${name}" true
     else if isBrokenRes == "not broken"
     then false
     else abort "unknown return value from isBroken': ${isBrokenRes}";

--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,42 @@
 #
 # This produces a text file with a list of all dependencies of conduit.
 #
-
+# --------------------------------------------------------------------
+#
+# If you would like override a package in the Haskell package set, and then
+# find all dependencies of that package, you can use the following code
+# as a starting point.  The following overrides "random".
+#
+# ```nix
+# let
+#   myHaskellPackageOverlay = self: super: {
+#     haskellPackages = super.haskellPackages.override {
+#       overrides = hself: hsuper: {
+#         random =
+#           let newRandomSrc = builtins.fetchGit {
+#                 url = "https://github.com/idontgetoutmuch/random.git";
+#                 rev = "4bb37cfd588996c55e62ec4f908b8ea7d99a38f6";
+#                 ref = "interface-to-performance";
+#               };
+#           in
+#           # Since cabal2nix has a transitive dependency on random, we need to
+#           # get the callCabal2nix function from the normal haskellPackages that
+#           # is not being overridden.
+#           (import <nixpkgs> {}).haskellPackages.callCabal2nix "random" newRandomSrc { };
+#       };
+#     };
+#   };
+#
+#   nixpkgs = import <nixpkgs> { overlays = [ myHaskellPackageOverlay ]; };
+# in
+# # This example derivation file is assumed to be in the current directory.  "./default.nix" is
+# # the current file you are looking at.
+# import ./default.nix {
+#   reverseDepsOf = "random";
+#   inherit nixpkgs;
+# }
+# ```
+#
 
 { # Find the reverse dependencies of this Haskell package.  This should be a
   # string matching a Haskell package name.
@@ -51,24 +86,17 @@ let
 
   isBroken' = drv:
     let tryEvalRes = builtins.tryEval (
-          if lib.isDerivation drv
-          then
-            if drv ? meta
-            then
-              if !(drv.meta ? broken)
-              then
-                if !(drv.meta ? hydraPlatforms)
-                then "not broken"
-                else
-                  if drv.meta.hydraPlatforms == lib.platforms.none
-                  then "hydraPlatforms none"
-                  else "not broken"
-              else
-                if drv.meta.broken
-                then "broken"
-                else "not broken"
-            else "no meta"
-          else "not drv"
+          if !lib.isDerivation drv
+          then "not drv"
+          else if !(drv ? meta)
+          then "no meta"
+          else if drv.meta.broken or false
+          then "broken"
+          else if (drv.meta.hydraPlatforms or lib.platforms.all) == lib.platforms.none
+          then "hydraPlatforms none"
+          else if (drv.meta.platforms or lib.platforms.all) == lib.platforms.none
+          then "platforms none"
+          else "not broken"
         );
     in
     if tryEvalRes.success
@@ -101,6 +129,8 @@ let
     then /* builtins.trace "broken: ${name}" */ true
     else if isBrokenRes == "hydraPlatforms none"
     then /* builtins.trace "hydraPlatforms none: ${name}" */ true
+    else if isBrokenRes == "platforms none"
+    then /* builtins.trace "platforms none: ${name}" */ true
     else if isBrokenRes == "not broken"
     then false
     else abort "unknown return value from isBroken': ${isBrokenRes}";


### PR DESCRIPTION
This PR adds a usage example for overriding a package in the Haskell package set (and then compiling all the reverse dependencies).

It also adds a check for `meta.platforms`, which was not handled before.

Fixes #2.